### PR TITLE
Add .editorconfig and VS Code settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["oxc.oxc-vscode", "3w36zj6.textlint", "editorconfig.editorconfig"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.defaultFormatter": "oxc.oxc-vscode",
+  "editor.formatOnSave": true,
+  "oxc.lint.enable": true,
+  "oxc.lint.configPath": ".oxlintrc.json"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.defaultFormatter": "oxc.oxc-vscode",
   "editor.formatOnSave": true,
-  "oxc.lint.enable": true,
-  "oxc.lint.configPath": ".oxlintrc.json"
+  "oxc.enable": true,
+  "oxc.configPath": ".oxlintrc.json"
 }


### PR DESCRIPTION
## Summary
- `.editorconfig` を追加（2スペース、LF、UTF-8、末尾改行・空白の設定）
- `.vscode/settings.json` を追加（oxfmt/oxlint 統合、formatOnSave 有効）
- `.vscode/extensions.json` を追加（oxc、textlint、editorconfig 拡張を推奨）

## Test plan
- [x] `npm run fmt:check` 通過
- [x] `npm run lint` 通過
- [x] `npm test` 全8テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)